### PR TITLE
Add override command for model namespace

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
     "require": {
         "php": "^7.2.9",
         "fideloper/proxy": "^4.0",
+        "healthengine/laravel-better-models": "^1.0",
         "healthengine/laravel-easy-aws": "^1.2",
         "healthengine/laravel-logging": "^1.0",
         "laravel/framework": "5.8.*",


### PR DESCRIPTION
This adds in an extra console command that overrides the built-in `make:model` command to change the default namespace for models to keep things a bit neater.